### PR TITLE
Add information for 2016 first-ana workshop

### DIFF
--- a/_posts/2016-11-01-starterkit-autumn-2016.md
+++ b/_posts/2016-11-01-starterkit-autumn-2016.md
@@ -1,13 +1,36 @@
 ---
 layout: post
 title: Starterkit Autumn 2016
-date: 2016-11-01
+date: 2016-11-28
+date: 2016-11-28 14:00 +0100
 categories: starterkit
+indico: https://indico.cern.ch/e/lhcb-starterkit-2016
 ---
 
-The third Starterkit, intended for new PhD and Master's students who started 
-working on LHCb in 2016. We expect to hold the workshop in November, though 
-this is subject to change.
+Fasten your seatbelts! The LHCb Starterkit is taking off for the third time.
 
-The organisers will send an email to `lhcb-general` when the registration is 
-open.
+This year's Starterkit will be held from the 28th of November to the 2nd of
+December 2016 at CERN.
+
+Registration is now open! You can find all necessary information, including the
+registration form on [the Indico page for the event][indico].
+
+The deadline to register is the 28th of October at 1500 CET. We expect the 
+event to be very popular, so please make sure to register as soon as possible.
+Spots will be assigned on a first-come first-served basis. The registration fee 
+of CHF 20 needs to be paid to the LHCb secretariat in advance of the workshop.
+It will be used to finance coffee breaks and a social event.
+
+Should you have any further questions, you can contact us at [by email][email].
+
+Please keep in mind that this event is specifically designed for early PhD
+students, or advanced Masters students. If you are not sure whether the
+Starterkit is at an appropriate level for you, you can have a look at [last
+year's lessons][first-ana-steps].
+
+If you are taking on new PhD students this year, please consider bringing this
+workshop to their attention.
+
+[indico]: https://indico.cern.ch/e/lhcb-starterkit-2016
+[email]: mailto:lhcb-starterkit@cern.ch
+[first-ana-steps]: https://lhcb.github.io/first-analysis-steps/


### PR DESCRIPTION
Update the [web page](https://lhcb.github.io/starterkit/starterkit/2016/11/01/starterkit-autumn-2016.html) for the November workshop. Most importantly, this adds the link to [Indico](https://indico.cern.ch/event/573121/) so that the listing on the home page links to the event.
